### PR TITLE
Adjusting kill to SIGINT which will save world

### DIFF
--- a/valheim/stop.yml
+++ b/valheim/stop.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   tasks:
   - name: "Stopping Valheim Server!"
-    shell: ps aux | grep -ie "valheim_server.x86_64" | grep -v grep | awk '{print $2}' | xargs kill -9
+    shell: ps aux | grep -ie "valheim_server.x86_64" | grep -v grep | awk '{print $2}' | xargs kill -2


### PR DESCRIPTION
Adjusting the kill command in valheim/stop.yml to use SIGINT. This gracefully closes the sever and saves the world instead of SIGKILL, which abruptly closes the server and results in world progress loss.